### PR TITLE
chore: clean codebase

### DIFF
--- a/Chapter 10/docker-compose-test.yml
+++ b/Chapter 10/docker-compose-test.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   mongo:
-    image: mongo:5
+    image: mongo:6
     volumes:
       - data:/data/db
 

--- a/Chapter 10/package.json
+++ b/Chapter 10/package.json
@@ -15,7 +15,7 @@
     "test:coverage": "tap --coverage-report=html --before=test/run-before.js test/**/**.test.js --after=test/run-after.js",
     "start": "fastify start -l info --options app.js",
     "dev": "npm run start -- --watch --pretty-logs --debug",
-    "mongo:start": "docker run -d -p 27017:27017 --rm --name fastify-mongo mongo:5",
+    "mongo:start": "docker run -d -p 27017:27017 --rm --name fastify-mongo mongo:6",
     "mongo:stop": "docker container stop fastify-mongo"
   },
   "keywords": [],

--- a/Chapter 10/test/helper-docker.js
+++ b/Chapter 10/test/helper-docker.js
@@ -3,7 +3,7 @@
 const Containers = {
   mongo: {
     name: 'fastify-mongo',
-    Image: 'mongo:5',
+    Image: 'mongo:6',
     Tty: false,
     HostConfig: {
       PortBindings: {

--- a/Chapter 6/package.json
+++ b/Chapter 6/package.json
@@ -13,7 +13,7 @@
     "test": "tap test/**/*.test.js --no-check-coverage",
     "start": "fastify start -l info --options app.js",
     "dev": "npm run start -- --watch --pretty-logs --debug",
-    "mongo:start": "docker run -d -p 27017:27017 --rm --name fastify-mongo mongo:5",
+    "mongo:start": "docker run -d -p 27017:27017 --rm --name fastify-mongo mongo:6",
     "mongo:stop": "docker container stop fastify-mongo"
   },
   "keywords": [],

--- a/Chapter 6/plugins/error-handler.js
+++ b/Chapter 6/plugins/error-handler.js
@@ -5,12 +5,12 @@ const fp = require('fastify-plugin')
 module.exports = fp(function errorHandlerPlugin (fastify, opts, next) {
   fastify.setErrorHandler((err, req, reply) => {
     if (reply.statusCode >= 500) {
-      req.log.error({ req, res: reply, err: err }, err?.message)
+      req.log.error({ req, res: reply, err }, err?.message)
       const error = new Error(`Fatal error. Contact the support team with the id ${req.id}`)
       reply.send(error)
       return
     }
-    req.log.info({ req, res: reply, err: err }, err?.message)
+    req.log.info({ req, res: reply, err }, err?.message)
     reply.send(err)
   })
   next()

--- a/Chapter 6/routes/autohooks.js
+++ b/Chapter 6/routes/autohooks.js
@@ -1,5 +1,5 @@
 'use strict'
 
-module.exports = async function rootAutoHooks (fastify, opts) {
-  // TODO: add application's hooks
+module.exports = async function rootAutoHooks (app, opts) {
+
 }

--- a/Chapter 9/package.json
+++ b/Chapter 9/package.json
@@ -15,7 +15,7 @@
     "test:coverage": "tap --coverage-report=html --before=test/run-before.js test/**/**.test.js --after=test/run-after.js",
     "start": "fastify start -l info --options app.js",
     "dev": "npm run start -- --watch --pretty-logs --debug",
-    "mongo:start": "docker run -d -p 27017:27017 --rm --name fastify-mongo mongo:5",
+    "mongo:start": "docker run -d -p 27017:27017 --rm --name fastify-mongo mongo:6",
     "mongo:stop": "docker container stop fastify-mongo"
   },
   "keywords": [],


### PR DESCRIPTION
Here are some changes to keep codebase consistent across different Chapters.

* It updates mongo version from 5 to 6 on every chapter as this version was used partially on Chapter 9 (Chapter 9/test/helper-docker.js) and on Chapter 13
* Duplicates Chapter 9 improvements to Chapter 6:
  - Simplifies `err` on `Chapter 6/plugins/error-handler.js`
  - Removes the TODO and renames `fastify` argument to `app` on `Chapter 6/routes/autohooks.js`