### PR TITLE
chore: Update action/checkout to version 3

### DIFF
--- a/Chapter 10/.github/workflows/fly.yml
+++ b/Chapter 10/.github/workflows/fly.yml
@@ -10,6 +10,6 @@ jobs:
       name: Deploy app
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
         - uses: superfly/flyctl-actions/setup-flyctl@master
         - run: flyctl deploy --remote-only


### PR DESCRIPTION
Continuous deployment was failing with the error that Node.js 12 actions are deprecated. Updated action/checkout to version 3 and the issue was resolved.